### PR TITLE
UI rendering corrections and constrained angles feature

### DIFF
--- a/script.js
+++ b/script.js
@@ -16,6 +16,8 @@ var radiansPer45Degrees = Math.PI / 4;
 
 var canvas = document.getElementById('canvas');
 var ctx = canvas.getContext('2d');
+ctx.lineJoin = 'bevel';
+
 var img = new Image();
 var rgb_color = color_choices[Math.floor(Math.random() * color_choices.length)] 
 var opaque_color =  'rgba(0,0,0,0.5)';

--- a/script.js
+++ b/script.js
@@ -449,6 +449,7 @@ function clearAll() {
 
     points = []
     masterPoints = []
+    masterColors = []
     document.querySelector('#json').innerHTML = ''
     document.querySelector('#python').innerHTML = ''
 }

--- a/script.js
+++ b/script.js
@@ -356,6 +356,14 @@ canvas.addEventListener('click', function(e) {
 
     points.push([x, y]);
 
+    ctx.beginPath();
+    ctx.strokeStyle = rgb_color;
+    ctx.arc(x, y, 5, 0, 2 * Math.PI);
+    // fill with white
+    ctx.fillStyle = 'white';
+    ctx.fill();
+    ctx.stroke();
+
     if(drawMode == "line" && points.length == 2) {
         closePath();
     }

--- a/script.js
+++ b/script.js
@@ -12,6 +12,8 @@ var color_choices = [
     "#CCCCCC",
 ];
 
+var radiansPer45Degrees = Math.PI / 4;
+
 var canvas = document.getElementById('canvas');
 var ctx = canvas.getContext('2d');
 var img = new Image();
@@ -28,7 +30,7 @@ var masterColors = [];
 
 var drawMode
 setDrawMode('polygon')
-
+var constrainAngles = false;
 var showNormalized = false;
 
 var modeMessage = document.querySelector('#mode');
@@ -166,6 +168,11 @@ function getParentPoints () {
     return parentPoints;
 }
 
+window.addEventListener('keyup', function(e) {
+    if (e.key === 'Shift') {
+        constrainAngles = false;
+    }
+});
 
 document.querySelector('#clipboard').addEventListener('click', function(e) {
     e.preventDefault();
@@ -198,6 +205,20 @@ canvas.addEventListener('mousemove', function(e) {
     // update x y coords
     var xcoord = document.querySelector('#x');
     var ycoord = document.querySelector('#y');
+
+    if(constrainAngles) {
+        var lastPoint = points[points.length - 1];
+        var dx = x - lastPoint[0];
+        var dy = y - lastPoint[1];
+        var angle = Math.atan2(dy, dx);
+        var length = Math.sqrt(dx * dx + dy * dy);
+        const snappedAngle = Math.round(angle / radiansPer45Degrees) * radiansPer45Degrees;
+        var new_x = lastPoint[0] + length * Math.cos(snappedAngle);
+        var new_y = lastPoint[1] + length * Math.sin(snappedAngle);
+        x = Math.round(new_x);
+        y = Math.round(new_y);
+    }
+
     xcoord.innerHTML = x;
     ycoord.innerHTML = y;
 
@@ -308,6 +329,19 @@ canvas.addEventListener('click', function(e) {
     var y = getScaledCoords(e)[1];
     x = Math.round(x);
     y = Math.round(y);
+
+    if(constrainAngles) {
+        var lastPoint = points[points.length - 1];
+        var dx = x - lastPoint[0];
+        var dy = y - lastPoint[1];
+        var angle = Math.atan2(dy, dx);
+        var length = Math.sqrt(dx * dx + dy * dy);
+        const snappedAngle = Math.round(angle / radiansPer45Degrees) * radiansPer45Degrees;
+        var new_x = lastPoint[0] + length * Math.cos(snappedAngle);
+        var new_y = lastPoint[1] + length * Math.sin(snappedAngle);
+        x = Math.round(new_x);
+        y = Math.round(new_y);
+    }
 
     // If starting point os clicked, we complete the polygon 
     if (drawMode === 'polygon' && points.length > 1) {
@@ -464,6 +498,10 @@ window.addEventListener('keydown', function(e) {
         e.stopImmediatePropagation()
 
         undo()
+    }
+
+    if (e.key === 'Shift') {
+        constrainAngles = true;
     }
 
     if (e.key === 'Escape') {

--- a/script.js
+++ b/script.js
@@ -103,50 +103,6 @@ function getScaledCoords(e) {
     return [x / scaleFactor, y / scaleFactor];
 }
 
-function drawCurrentPolygon (cursorX, cursorY) {
-    //ctx.clearRect(0, 0, canvas.width, canvas.height);
-    ctx.drawImage(img, 0, 0);
-    for (var i = 0; i < points.length - 1; i++) {
-        // draw arc around each point
-        ctx.beginPath();
-        ctx.strokeStyle = rgb_color;
-        ctx.arc(points[i][0], points[i][1], 5, 0, 2 * Math.PI);
-        // fill with white
-        ctx.fillStyle = 'white';
-        ctx.fill();
-        ctx.stroke();
-        drawLine(points[i][0], points[i][1], points[i + 1][0], points[i + 1][1]);
-    }
-    
-    if ((points.length > 0 && drawMode == "polygon") || (points.length > 0 && points.length < 2 && drawMode == "line")) {
-        ctx.beginPath();
-        ctx.strokeStyle = rgb_color;
-        ctx.arc(points[i][0], points[i][1], 5, 0, 2 * Math.PI);
-        // fill with white
-        ctx.fillStyle = 'white';
-        ctx.fill();
-        ctx.stroke();
-
-        if (cursorX && cursorY) {
-            drawLine(points[points.length - 1][0], points[points.length - 1][1], cursorX, cursorY);
-        }
-
-        if (points.length == 2 && drawMode == "line") {
-            console.log("line");
-            // draw arc around each point
-            ctx.beginPath();
-            ctx.strokeStyle = rgb_color;
-            ctx.arc(points[0][0], points[0][1], 5, 0, 2 * Math.PI);
-            // fill with white
-            ctx.fillStyle = 'white';
-            ctx.fill();
-            ctx.stroke();
-            masterPoints.push(points);
-            points = [];
-        }
-    }
-}
-
 function drawAllPolygons () {
     // draw all points for previous regions
     for (var i = 0; i < masterPoints.length; i++) {
@@ -244,8 +200,32 @@ canvas.addEventListener('mousemove', function(e) {
     ycoord.innerHTML = y;
 
     if (canvas.style.cursor == 'crosshair') {
-        drawCurrentPolygon(x, y)
+        ctx.clearRect(0, 0, canvas.width, canvas.height);
+        ctx.drawImage(img, 0, 0);
+        
         drawAllPolygons();
+
+        for (var i = 0; i < points.length - 1; i++) {
+            // draw arc around each point
+            ctx.beginPath();
+            ctx.strokeStyle = rgb_color;
+            ctx.arc(points[i][0], points[i][1], 5, 0, 2 * Math.PI);
+            // fill with white
+            ctx.fillStyle = 'white';
+            ctx.fill();
+            ctx.stroke();
+            drawLine(points[i][0], points[i][1], points[i + 1][0], points[i + 1][1]);
+        }
+        if ((points.length > 0 && drawMode == "polygon") || (points.length > 0 && points.length < 2 && drawMode == "line")) {
+            ctx.beginPath();
+            ctx.strokeStyle = rgb_color;
+            ctx.arc(points[i][0], points[i][1], 5, 0, 2 * Math.PI);
+            // fill with white
+            ctx.fillStyle = 'white';
+            ctx.fill();
+            ctx.stroke();
+            drawLine(points[points.length - 1][0], points[points.length - 1][1], x, y);
+        }
     }
 });
 
@@ -367,7 +347,7 @@ canvas.addEventListener('click', function(e) {
     if (points.length > 2 && drawMode == "polygon") {
         distX = x - points[0][0];
         distY = y - points[0][1];
-        // stroke is 3px and centered on the circle (i.e. 1/2 * 3px) and arc radius is 5px
+        // stroke is 3px and centered on the circle (i.e. 1/2 * 3px) and arc radius is 
         if(Math.sqrt(distX * distX + distY * distY) <= 6.5) {
             closePath();
             return;
@@ -430,8 +410,9 @@ document.addEventListener('keydown', function(e) {
 })
 
 function draw () {
-    drawCurrentPolygon()
+    
     drawAllPolygons()
+    drawCurrentPolygon()
     var parentPoints = getParentPoints()
     writePoints(parentPoints)
 }

--- a/script.js
+++ b/script.js
@@ -93,7 +93,7 @@ function drawLine(x1, y1, x2, y2) {
     ctx.lineWidth = 5;
     ctx.moveTo(x1, y1);
     ctx.lineTo(x2, y2);
-    ctx.stroke();
+    // ctx.stroke();
 }
 
 function getScaledCoords(e) {
@@ -112,6 +112,17 @@ function drawAllPolygons () {
         for (var j = 1; j < newpoints.length; j++) {
             // draw all lines
             drawLine(newpoints[j - 1][0], newpoints[j - 1][1], newpoints[j][0], newpoints[j][1]);
+
+            // fill
+            ctx.beginPath();
+            ctx.fillStyle = opaque_color;
+            ctx.moveTo(newpoints[0][0], newpoints[0][1]);
+            for (var j = 1; j < newpoints.length; j++) {
+                ctx.lineTo(newpoints[j][0], newpoints[j][1]);
+            }
+            ctx.closePath();
+            ctx.fill();
+            ctx.stroke();
         }
         drawLine(newpoints[newpoints.length - 1][0], newpoints[newpoints.length - 1][1], newpoints[0][0], newpoints[0][1]);
         // draw arc around each point
@@ -124,15 +135,7 @@ function drawAllPolygons () {
             ctx.fill();
             ctx.stroke();
         }
-        // fill
-        ctx.beginPath();
-        ctx.fillStyle = opaque_color;
-        ctx.moveTo(newpoints[0][0], newpoints[0][1]);
-        for (var j = 1; j < newpoints.length; j++) {
-            ctx.lineTo(newpoints[j][0], newpoints[j][1]);
-        }
-        ctx.closePath();
-        ctx.fill();
+        
     }
 }
 
@@ -206,20 +209,24 @@ canvas.addEventListener('mousemove', function(e) {
         drawAllPolygons();
 
         for (var i = 0; i < points.length - 1; i++) {
+            ctx.strokeStyle = rgb_color;
             drawLine(points[i][0], points[i][1], points[i + 1][0], points[i + 1][1]);
+            ctx.stroke();
             // draw arc around each point
             ctx.beginPath();
-            ctx.strokeStyle = rgb_color;
             ctx.arc(points[i][0], points[i][1], 5, 0, 2 * Math.PI);
             // fill with white
             ctx.fillStyle = 'white';
             ctx.fill();
             ctx.stroke();
         }
+
+
         if ((points.length > 0 && drawMode == "polygon") || (points.length > 0 && points.length < 2 && drawMode == "line")) {
-            drawLine(points[points.length - 1][0], points[points.length - 1][1], x, y);
-            ctx.beginPath();
             ctx.strokeStyle = rgb_color;
+            drawLine(points[points.length - 1][0], points[points.length - 1][1], x, y);
+            ctx.stroke(); // new
+            ctx.beginPath();
             ctx.arc(points[i][0], points[i][1], 5, 0, 2 * Math.PI);
             // fill with white
             ctx.fillStyle = 'white';

--- a/script.js
+++ b/script.js
@@ -206,6 +206,7 @@ canvas.addEventListener('mousemove', function(e) {
         drawAllPolygons();
 
         for (var i = 0; i < points.length - 1; i++) {
+            drawLine(points[i][0], points[i][1], points[i + 1][0], points[i + 1][1]);
             // draw arc around each point
             ctx.beginPath();
             ctx.strokeStyle = rgb_color;
@@ -214,9 +215,9 @@ canvas.addEventListener('mousemove', function(e) {
             ctx.fillStyle = 'white';
             ctx.fill();
             ctx.stroke();
-            drawLine(points[i][0], points[i][1], points[i + 1][0], points[i + 1][1]);
         }
         if ((points.length > 0 && drawMode == "polygon") || (points.length > 0 && points.length < 2 && drawMode == "line")) {
+            drawLine(points[points.length - 1][0], points[points.length - 1][1], x, y);
             ctx.beginPath();
             ctx.strokeStyle = rgb_color;
             ctx.arc(points[i][0], points[i][1], 5, 0, 2 * Math.PI);
@@ -224,7 +225,6 @@ canvas.addEventListener('mousemove', function(e) {
             ctx.fillStyle = 'white';
             ctx.fill();
             ctx.stroke();
-            drawLine(points[points.length - 1][0], points[points.length - 1][1], x, y);
         }
     }
 });


### PR DESCRIPTION
# Description

I added a new feature where users can hold down 'Shift' to constrain angles to 45-degree increments. This is especially helpful for some special cases where lines are often vertical or horizontal. I also fixed a lot of rendering bugs. For example, previously, the 'Clear all polygons' feature caused polygons/lines to change color upon closure. Additionally, I changed the rendering order so that shapes being drawn appear *above* rather than *below* the existing shapes. I also changed the order so that the polygon fill is not drawn over the lines, and the lines are not drawn over the nodes. Previously, the lines were drawn in the same color until a polygon was drawn and then lines would be drawn in the next color in the queue. Now each line is drawn in a new color. Previously the nodes were not drawn on the canvas until the mouse moved, but now they are drawn as soon as the user clicks. And lastly, I changed the lineJoin type to be bevel instead of miter because small angles could cause ugly sharp points that extended beyond the nodes.

## Type of change

Please delete options that are not relevant.

-   [ ] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)

## How has this change been tested, please provide a testcase or example of how you tested the change?

I tested this manually by using Safari and Chrome.

## Any specific deployment considerations

No.
