### PR TITLE
UI improvements and bug fixes

### DIFF
--- a/script.js
+++ b/script.js
@@ -35,7 +35,7 @@ var constrainAngles = false;
 var showNormalized = false;
 
 var modeMessage = document.querySelector('#mode');
-var coords = document.querySelector('#coords');
+// var coords = document.querySelector('#coords');
 
 function clipboard(selector) {
     var copyText = document.querySelector(selector).innerText;
@@ -313,7 +313,7 @@ canvas.addEventListener('drop', function(e) {
         ctx.drawImage(img, 0, 0);
     };
     // show coords
-    document.getElementById('coords').style.display = 'inline-block';
+    // document.getElementById('coords').style.display = 'inline-block';
 });
 
 function writePoints(parentPoints) {

--- a/script.js
+++ b/script.js
@@ -177,6 +177,13 @@ canvas.addEventListener('wheel', function(e) {
     zoom(delta);
 });
 
+canvas.addEventListener('mouseleave', function(e) {
+    var xcoord = document.querySelector('#x');
+    var ycoord = document.querySelector('#y'); 
+    xcoord.innerHTML = '';
+    ycoord.innerHTML = '';
+});
+
 // on canvas hover, if cursor is crosshair, draw line from last point to cursor
 canvas.addEventListener('mousemove', function(e) {
     var x = getScaledCoords(e)[0];
@@ -202,6 +209,13 @@ canvas.addEventListener('mousemove', function(e) {
         y = Math.round(new_y);
     }
 
+    // sometimes, a mousemove event is leaving the canvas and has coordinates outside the canvas
+    // however, due to the cursors being used, we do not need to check if it is larger than canvas.width or canvas.height
+    if (x < 0 || y < 0 ){
+        xcoord.innerHTML = '';
+        ycoord.innerHTML = '';
+        return;
+    }
     xcoord.innerHTML = x;
     ycoord.innerHTML = y;
 
@@ -441,10 +455,15 @@ function undo () {
     highlightButtonInteraction('#undo')
 
     if (points.length > 0) {
+
         points.pop()
         
         clearDrawings()
         draw()
+
+        if(points.length === 0){
+            return;
+        }
         ctx.strokeStyle = rgb_color;
         var i = 0;
         for (; i < points.length - 1; i++) {
@@ -459,13 +478,13 @@ function undo () {
             ctx.stroke();
         }
 
-        // draw arc around point n
-        ctx.beginPath();
-        ctx.arc(points[i][0], points[i][1], 5, 0, 2 * Math.PI);
-        // fill with white
-        ctx.fillStyle = 'white';
-        ctx.fill();
-        ctx.stroke();
+            // draw arc around point n
+            ctx.beginPath();
+            ctx.arc(points[i][0], points[i][1], 5, 0, 2 * Math.PI);
+            // fill with white
+            ctx.fillStyle = 'white';
+            ctx.fill();
+            ctx.stroke();
     }
 }
 

--- a/script.js
+++ b/script.js
@@ -41,6 +41,11 @@ function clipboard(selector) {
     navigator.clipboard.writeText(copyText);
 }
 
+function clearDrawings() {
+    ctx.clearRect(0, 0, canvas.width, canvas.height);
+    ctx.drawImage(img, 0, 0);
+}
+
 function zoom(clicks) {
     // if w > 60em, stop
     if ((scaleFactor + clicks * scaleSpeed) * img.width > 40 * 16) {
@@ -58,9 +63,7 @@ function closePath() {
     canvas.style.cursor = 'default';
     masterPoints.push(points);
     masterColors.push(rgb_color);
-    ctx.clearRect(0, 0, canvas.width, canvas.height);
-    ctx.drawImage(img, 0, 0);
-    
+    clearDrawings();
     drawAllPolygons();
     points = [];
 
@@ -203,8 +206,7 @@ canvas.addEventListener('mousemove', function(e) {
     ycoord.innerHTML = y;
 
     if (canvas.style.cursor == 'crosshair') {
-        ctx.clearRect(0, 0, canvas.width, canvas.height);
-        ctx.drawImage(img, 0, 0);
+        clearDrawings();
         
         drawAllPolygons();
 
@@ -426,7 +428,6 @@ document.addEventListener('keydown', function(e) {
 
 function draw () {
     drawAllPolygons()
-    drawCurrentPolygon()
     var parentPoints = getParentPoints()
     writePoints(parentPoints)
 }
@@ -439,8 +440,33 @@ function highlightButtonInteraction (buttonId) {
 function undo () {
     highlightButtonInteraction('#undo')
 
-    points.pop()
-    draw()
+    if (points.length > 0) {
+        points.pop()
+        
+        clearDrawings()
+        draw()
+        ctx.strokeStyle = rgb_color;
+        var i = 0;
+        for (; i < points.length - 1; i++) {
+            drawLine(points[i][0], points[i][1], points[i + 1][0], points[i + 1][1]);
+            ctx.stroke();
+            // draw arc around each point
+            ctx.beginPath();
+            ctx.arc(points[i][0], points[i][1], 5, 0, 2 * Math.PI);
+            // fill with white
+            ctx.fillStyle = 'white';
+            ctx.fill();
+            ctx.stroke();
+        }
+
+        // draw arc around point n
+        ctx.beginPath();
+        ctx.arc(points[i][0], points[i][1], 5, 0, 2 * Math.PI);
+        // fill with white
+        ctx.fillStyle = 'white';
+        ctx.fill();
+        ctx.stroke();
+    }
 }
 
 document.querySelector('#undo').addEventListener('click', function(e) {
@@ -451,6 +477,7 @@ function discardCurrentPolygon () {
     highlightButtonInteraction('#discard-current')
 
     points = []
+    clearDrawings()
     draw()
 }
 
@@ -460,10 +487,7 @@ document.querySelector('#discard-current').addEventListener('click', function(e)
 
 function clearAll() {
     highlightButtonInteraction('#clear')
-
-    ctx.clearRect(0, 0, canvas.width, canvas.height)
-    ctx.drawImage(img, 0, 0)
-
+    clearDrawings()
     points = []
     masterPoints = []
     masterColors = []
@@ -492,7 +516,6 @@ window.addEventListener('keydown', function(e) {
     if (e.key === 'z' && (e.ctrlKey || e.metaKey)) {
         e.preventDefault()
         e.stopImmediatePropagation()
-
         undo()
     }
 

--- a/script.js
+++ b/script.js
@@ -11,6 +11,7 @@ var color_choices = [
     "#0000FF",
     "#CCCCCC",
 ];
+// if you want choices to be kind of random, shuffle the array once here
 
 var radiansPer45Degrees = Math.PI / 4;
 
@@ -18,7 +19,7 @@ var canvas = document.getElementById('canvas');
 var ctx = canvas.getContext('2d');
 
 var img = new Image();
-var rgb_color = color_choices[Math.floor(Math.random() * color_choices.length)] 
+var rgb_color = "#FF00FF"; 
 var fill_color =  'rgba(0,0,0,0.35)';
 
 var scaleFactor = 1;
@@ -81,17 +82,8 @@ function onPathClose() {
     masterColors.push(rgb_color);
     clearDrawings();
     drawAllPolygons();
-
-    // dont choose a color that has already been chosen
-    var remaining_choices = color_choices.filter(function(x) {
-        return !masterColors.includes(x);
-    });
     
-    if (remaining_choices.length == 0) {
-        remaining_choices = color_choices;
-    }
-
-    rgb_color = remaining_choices[Math.floor(Math.random() * remaining_choices.length)];
+    rgb_color = color_choices[(masterColors.length) % (color_choices.length)];
 }
 
 // placeholder image

--- a/script.js
+++ b/script.js
@@ -487,6 +487,7 @@ function clearAll() {
     points = [];
     masterPoints = [];
     masterColors = [];
+    rgb_color = color_choices[0];
     document.querySelector('#json').innerHTML = '';
     document.querySelector('#python').innerHTML = '';
 }

--- a/script.js
+++ b/script.js
@@ -16,7 +16,6 @@ var radiansPer45Degrees = Math.PI / 4;
 
 var canvas = document.getElementById('canvas');
 var ctx = canvas.getContext('2d');
-ctx.lineJoin = 'bevel';
 
 var img = new Image();
 var rgb_color = color_choices[Math.floor(Math.random() * color_choices.length)] 
@@ -137,6 +136,7 @@ function drawAllPolygons () {
     ctx.fill();
     
     ctx.lineWidth = 5;
+    ctx.lineJoin = 'bevel';
     for (var i = 0; i < masterPoints.length; i++) {
         var newpoints = masterPoints[i];
         ctx.strokeStyle = masterColors[i];
@@ -248,6 +248,7 @@ canvas.addEventListener('mousemove', function(e) {
         for (var i = 0; i < points.length - 1; i++) {
             ctx.strokeStyle = rgb_color;
             ctx.beginPath();
+            ctx.lineJoin = 'bevel';
             drawLine(points[i][0], points[i][1], points[i + 1][0], points[i + 1][1]);
             ctx.closePath();
             ctx.stroke();
@@ -264,6 +265,7 @@ canvas.addEventListener('mousemove', function(e) {
 
         if ((points.length > 0 && drawMode == "polygon") || (points.length > 0 && points.length < 2 && drawMode == "line")) {
             ctx.beginPath();
+            ctx.lineJoin = 'bevel';
             ctx.strokeStyle = rgb_color;
             drawLine(points[points.length - 1][0], points[points.length - 1][1], x, y);
             ctx.closePath();

--- a/script.js
+++ b/script.js
@@ -16,6 +16,8 @@ var radiansPer45Degrees = Math.PI / 4;
 
 var canvas = document.getElementById('canvas');
 var ctx = canvas.getContext('2d');
+ctx.lineJoin = 'bevel';
+
 var img = new Image();
 var rgb_color = color_choices[Math.floor(Math.random() * color_choices.length)] 
 var fill_color =  'rgba(0,0,0,0.35)';

--- a/script.js
+++ b/script.js
@@ -457,10 +457,10 @@ document.querySelector('#mode-line').addEventListener('click', function(e) {
 })
 
 document.addEventListener('keydown', function(e) {
-    if (e.key == 'l') {
+    if (e.key == 'l' || e.key == 'L') {
         setDrawMode('line')
     }
-    if (e.key == 'p') {
+    if (e.key == 'p' || e.key == 'P') {
         setDrawMode('polygon')
     }
 })

--- a/script.js
+++ b/script.js
@@ -425,7 +425,6 @@ document.addEventListener('keydown', function(e) {
 })
 
 function draw () {
-    
     drawAllPolygons()
     drawCurrentPolygon()
     var parentPoints = getParentPoints()
@@ -489,28 +488,6 @@ document.querySelector('#save-image').addEventListener('click', function(e) {
     saveImage()
 })
 
-function completeCurrentPolygon () {
-    canvas.style.cursor = 'default'
-
-    // save current polygon points
-    masterPoints.push(points)
-    points = []
-
-    // dont choose a color that has already been chosen
-    var remaining_choices = color_choices.filter(function(x) {
-        return !masterColors.includes(x)
-    });
-    
-    if (remaining_choices.length == 0) {
-        remaining_choices = color_choices
-    }
-
-    rgb_color = remaining_choices[Math.floor(Math.random() * remaining_choices.length)]
-    masterColors.push(rgb_color)
-
-    draw()
-}
-
 window.addEventListener('keydown', function(e) {
     if (e.key === 'z' && (e.ctrlKey || e.metaKey)) {
         e.preventDefault()
@@ -539,6 +516,8 @@ window.addEventListener('keydown', function(e) {
     }
 
     if (e.key === 'Enter') {
-        completeCurrentPolygon()
+        if(points.length > 2) {
+            closePath()
+        }
     }
 })


### PR DESCRIPTION
# Description

Major changes:
- [Feature] Pre-render the canvas so we don't have to redraw the canvas on every draw update.
- [Bug fix] Closing polygon using 'Enter' now clears the canvas before redrawing.
- [Feature] Do not accumulate darkness of overlapping shapes. Instead, fill all polygons at the same time and blend colors once for a uniform fill.
- [Bug fix] Immediately refresh the canvas on undo. Previously, one had to move the mouse to update the canvas.

Other changes:
- Allow user to press upper or lower case letters to change draw mode (i.e. 'l'/'L' and 'p'/'P'). This reduces confusion because the documentation currently says press 'L' or 'P' but it means 'l' or 'p'. Now either are acceptable.
- Some minimal refactoring
- Now colors cycle periodically instead of randomly. The old method permitted some double coloring after all the colors in `color_choices` had been exhausted.

## Type of change

Please delete options that are not relevant.

-   [ ] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] This change requires a documentation update

## How has this change been tested, please provide a testcase or example of how you tested the change?

Tested manually in Safari and Chrome.

## Any specific deployment considerations

Some documentation might need to be updated to reflect the change in the keys used to switch draw modes.
