### PR TITLE
bug fix: copy button should copy points not static text

### DIFF
--- a/index.html
+++ b/index.html
@@ -106,8 +106,8 @@
                     <div class="points-output section">
                         <h2>NumPy Points</h2>
                         <p>Copy the points below into your Python code.</p>
-                        <a href="" id="clipboard" class="widgetButton">Copy Python to Clipboard</a>
-                        <pre id="python">
+                        <a href="" id="copyPythonButton" class="widgetButton">Copy Python to Clipboard</a>
+                        <pre id="pythonCode">
                             <code>
                             </code>
                         </pre>
@@ -118,8 +118,8 @@
                         <details>
                             <summary>View JSON Points</summary>
                             <h2>JSON Points</h2>
-                            <a href="" id="clipboardJSON" class="widgetButton">Copy JSON to Clipboard</a>
-                            <pre id="json">
+                            <a href="" id="copyJSONButton" class="widgetButton">Copy JSON to Clipboard</a>
+                            <pre id="jsonCode">
                                 <code>
                                 </code>
                             </pre>

--- a/index.html
+++ b/index.html
@@ -48,7 +48,7 @@
                         </ol>
                         <h2>Coordinates</h2>
                         <p>Copy the points below, formatted as NumPy arrays, into your Python code.</p>
-                        <a href="" id="clipboard" class="widgetButton left">Copy Python to Clipboard</a>
+                        <a href="" id="copyPythonButton" class="widgetButton left">Copy Python to Clipboard</a>
                         <label for="normalize-checkbox">Show Normalized Points from 0-1</label>
                         <input type="checkbox" id="normalize-checkbox" name="normalize-checkbox" value="normalize-checkbox">
                         <pre id="python">
@@ -58,7 +58,7 @@
                         <details>
                             <summary>View JSON Points</summary>
                             <h2>JSON Points</h2>
-                            <a href="" id="clipboardJSON" class="widgetButton">Copy JSON to Clipboard</a>
+                            <a href="" id="copyJSONButton" class="widgetButton">Copy JSON to Clipboard</a>
                             <pre id="json">
                                 <code>
                                 </code>

--- a/script.js
+++ b/script.js
@@ -191,14 +191,14 @@ window.addEventListener('keyup', function(e) {
     }
 });
 
-document.querySelector('#clipboard').addEventListener('click', function(e) {
+document.querySelector('#copyPythonButton').addEventListener('click', function(e) {
     e.preventDefault();
-    clipboard("#clipboard");
+    clipboard("#pythonCode");
 });
 
-document.querySelector('#clipboardJSON').addEventListener('click', function(e) {
+document.querySelector('#copyJSONButton').addEventListener('click', function(e) {
     e.preventDefault();
-    clipboard("#clipboardJSON");
+    clipboard("#jsonCode");
 });
 
 canvas.addEventListener('dragover', function(e) {
@@ -348,8 +348,8 @@ function writePoints(parentPoints) {
     parentPoints = parentPoints.filter(points => !!points.length);
 
     if (!parentPoints.length) {
-        document.querySelector('#python').innerHTML = '';
-        document.querySelector('#json').innerHTML;
+        document.querySelector('#pythonCode').innerHTML = '';
+        document.querySelector('#jsonCode').innerHTML;
         return;
     }
 
@@ -359,14 +359,14 @@ function writePoints(parentPoints) {
                                 return `[${point[0]}, ${point[1]}]`;}).join(', ')}])`;
                             }).join(',\n')}\n]`;
 
-    document.querySelector('#python').innerHTML = code_template;
+    document.querySelector('#pythonCode').innerHTML = code_template;
 
     var json_template = `{\n${parentPoints.map(function(points) {
         return `    [${points.map(function(point) {
             return `{"x": ${point[0]}, "y": ${point[1]}}`;}).join(', ')}]`;
         }).join(',\n')}\n}`;
 
-    document.querySelector('#json').innerHTML = json_template;
+    document.querySelector('#jsonCode').innerHTML = json_template;
 }
 
 canvas.addEventListener('click', function(e) {
@@ -516,8 +516,8 @@ function clearAll() {
     masterPoints = [];
     masterColors = [];
     rgb_color = color_choices[0];
-    document.querySelector('#json').innerHTML = '';
-    document.querySelector('#python').innerHTML = '';
+    document.querySelector('#jsonCode').innerHTML = '';
+    document.querySelector('#pythonCode').innerHTML = '';
 }
 
 document.querySelector('#clear').addEventListener('click', function(e) {

--- a/script.js
+++ b/script.js
@@ -64,6 +64,8 @@ function blitCachedCanvas() {
 
 function clipboard(selector) {
     var copyText = document.querySelector(selector).innerText;
+    // strip whitespace on left and right
+    copyText = copyText.replace(/^\s+|\s+$/g, '');
     navigator.clipboard.writeText(copyText);
 }
 
@@ -244,12 +246,12 @@ window.addEventListener('keyup', function(e) {
 
 document.querySelector('#copyPythonButton').addEventListener('click', function(e) {
     e.preventDefault();
-    clipboard("#pythonCode");
+    clipboard("#python");
 });
 
 document.querySelector('#copyJSONButton').addEventListener('click', function(e) {
     e.preventDefault();
-    clipboard("#jsonCode");
+    clipboard("#json");
 });
 
 canvas.addEventListener('dragover', function(e) {
@@ -422,8 +424,8 @@ function writePoints(parentPoints) {
     parentPoints = parentPoints.filter(points => !!points.length);
 
     if (!parentPoints.length) {
-        document.querySelector('#pythonCode').innerHTML = '';
-        document.querySelector('#jsonCode').innerHTML;
+        document.querySelector('#python').innerHTML = '';
+        document.querySelector('#json').innerHTML;
         return;
     }
 
@@ -433,14 +435,14 @@ function writePoints(parentPoints) {
                                 return `[${point[0]}, ${point[1]}]`;}).join(', ')}])`;
                             }).join(',\n')}\n]`;
 
-    document.querySelector('#pythonCode').innerHTML = code_template;
+    document.querySelector('#python').innerHTML = code_template;
 
     var json_template = `{\n${parentPoints.map(function(points) {
         return `    [${points.map(function(point) {
             return `{"x": ${point[0]}, "y": ${point[1]}}`;}).join(', ')}]`;
         }).join(',\n')}\n}`;
 
-    document.querySelector('#jsonCode').innerHTML = json_template;
+    document.querySelector('#json').innerHTML = json_template;
 }
 
 canvas.addEventListener('mousedown', function(e) {


### PR DESCRIPTION
# Description

There was a documented bug #2 where the copy buttons do not copy the points but the string "Copy Python to Clipboard". Now it is fixed and properly copies the text in the corresponding code view (JSON or Python). 

## Type of change

Please delete options that are not relevant.

-   [ ] Bug fix (non-breaking change which fixes an issue)

## How has this change been tested, please provide a testcase or example of how you tested the change?

It has been manually tested in Safari.
