### PR TITLE
Add support for WebP image format

### DIFF
--- a/script.js
+++ b/script.js
@@ -289,24 +289,19 @@ canvas.addEventListener('mousemove', function(e) {
 canvas.addEventListener('drop', function(e) {
     e.preventDefault();
     var file = e.dataTransfer.files[0];
+
+    // only allow image files
+    var supportedImageTypes = ['image/png', 'image/jpeg', 'image/jpg', 'image/webp'];
+    if (!supportedImageTypes.includes(file.type)) {
+        alert('Only PNG, JPEG, JPG, and WebP files are allowed.');
+        return;
+    }
+
     var reader = new FileReader();
-    
     reader.onload = function(event) {
-        // only allow image files
         img.src = event.target.result;
     };
     reader.readAsDataURL(file);
-
-    var mime_type = file.type;
-
-    if (
-        mime_type != 'image/png' &&
-        mime_type != 'image/jpeg' &&
-        mime_type != 'image/jpg'
-    ) {
-        alert('Only PNG, JPEG, and JPG files are allowed.');
-        return;
-    }
 
     img.onload = function() {
         scaleFactor = 0.25;


### PR DESCRIPTION
# Description

Added support for WebP image format. Pretty much every browser, except for IE, [supports this format](https://caniuse.com/?search=webp).

No major changes in code required, since the image decoding is handled by the native `Image` object.

## Type of change

-   [x] New feature (non-breaking change which adds functionality)

## How has this change been tested, please provide a testcase or example of how you tested the change?

WebP image:

- Dragged a webp image to the canvas
- Created some polygons on top of it
- Saved annotated image to validate export

PNG/JPEG/JPG images:

- Dragged other supported images to the canvas to validate that other images still work

Other files:

- Dragged a couple of text files to the canvas to make sure that non-image files throw an alert