### PR TITLE
Fix image sizing after drop. Also improve zoom behavior.

### DIFF
--- a/index.html
+++ b/index.html
@@ -35,7 +35,7 @@
                     <li><a href="https://github.com/roboflow/polygonzone" target="_blank">View Source Code</a></li>
                 </ul>
             </nav>
-            <div class="flex">
+            <div class="content">
                 <div class="left">
                     <div class="how-to section">
                         <h1>PolygonZone</h1>
@@ -125,7 +125,9 @@
                         </div>
                     </div>
 
-                    <canvas id="canvas"></canvas>
+                    <div class="image-container">
+                        <canvas id="canvas"></canvas>
+                    </div>
                 </div>
             </div>
         </main>

--- a/script.js
+++ b/script.js
@@ -15,6 +15,7 @@ var color_choices = [
 
 var radiansPer45Degrees = Math.PI / 4;
 
+var imageContainer = document.querySelector('.image-container');
 var canvas = document.getElementById('canvas');
 var mainCtx = canvas.getContext('2d');
 var offScreenCanvas = document.createElement('canvas');
@@ -68,16 +69,30 @@ function isClockwise(vertices) {
 }
 
 function zoom(clicks) {
-    // if w > 60em, stop
-    if ((scaleFactor + clicks * scaleSpeed) * img.width > 40 * 16) {
-        return;
+    var newScaleFactor = scaleFactor + clicks * scaleSpeed;
+    newScaleFactor = Math.max(0.1, Math.min(newScaleFactor, 1));
+
+    const maxWidth = imageContainer.offsetWidth * 0.95;
+    const maxHeight = imageContainer.offsetHeight * 0.95;
+
+    let newWidth = img.width * newScaleFactor;
+    let newHeight = img.height * newScaleFactor;
+
+    if (newWidth > maxWidth) {
+        newHeight = (maxWidth / newWidth) * newHeight;
+        newWidth = maxWidth;
+        newScaleFactor = newWidth / img.width;
     }
-    scaleFactor += clicks * scaleSpeed;
-    scaleFactor = Math.max(0.1, Math.min(scaleFactor, 0.8));
-    var w = img.width * scaleFactor;
-    var h = img.height * scaleFactor;
-    canvas.style.width = w + 'px';
-    canvas.style.height = h + 'px';
+
+    if (newHeight > maxHeight) {
+        newWidth = (maxHeight / newHeight) * newWidth;
+        newHeight = maxHeight;
+        newScaleFactor = newHeight / img.height;
+    }
+
+    scaleFactor = newScaleFactor;
+    canvas.style.width = newWidth + 'px';
+    canvas.style.height = newHeight + 'px';
 }
 
 function onPathClose() {
@@ -309,13 +324,31 @@ canvas.addEventListener('drop', function(e) {
     }
 
     img.onload = function() {
-        scaleFactor = 0.25;
-        canvas.style.width = img.width * scaleFactor + 'px';
-        canvas.style.height = img.height * scaleFactor + 'px';
         canvas.width = img.width;
         canvas.height = img.height;
         offScreenCanvas.width = img.width;
         offScreenCanvas.height = img.height;
+
+        const maxWidth = imageContainer.offsetWidth * 0.95;
+        const maxHeight = imageContainer.offsetHeight * 0.95;
+
+        let newWidth = img.width;
+        let newHeight = img.height;
+
+        if (newWidth > maxWidth) {
+            newHeight = (maxWidth / newWidth) * newHeight;
+            newWidth = maxWidth;
+        }
+
+        if (newHeight > maxHeight) {
+            newWidth = (maxHeight / newHeight) * newWidth;
+            newHeight = maxHeight;
+        }
+
+        scaleFactor = newWidth / img.width;
+
+        canvas.style.width = newWidth + 'px';
+        canvas.style.height = newHeight + 'px';
         canvas.style.borderRadius = '10px';
         offScreenCtx.drawImage(img, 0, 0);
         blitCachedCanvas();

--- a/styles.css
+++ b/styles.css
@@ -18,7 +18,16 @@ pre {
 }
 body {
     background: white;
-    min-height: 50vh;
+    height: 100vh;
+    margin: 0;
+    padding: 0;
+}
+main {
+    display: flex;
+    flex-direction: column;
+    height: 100vh;
+    margin: 0;
+    padding: 0;
 }
 h1 {
     font-size: 28px;
@@ -30,9 +39,6 @@ details {
     width: 100%;
     margin: 0;
     text-align: left;
-}
-.right {
-    min-height: calc(100vh - 10em);
 }
 nav {
     border-bottom: 1px solid lightgrey;
@@ -59,8 +65,9 @@ a {
     color: #5400ec;
     text-decoration: none;
 }
-.flex {
+.content {
     display: flex;
+    flex-grow: 1;
 }
 .left {
     flex: 50%;
@@ -72,9 +79,14 @@ a {
     flex: 50%;
     padding: 0 2em;
     box-sizing: border-box;
+    display: flex;
+    flex-direction: column;
+}
+.image-container {
+    flex-grow: 1;
 }
 @media screen and (max-width: 900px) {
-    .flex {
+    .content {
         display: block;
     }
     .left, .right {


### PR DESCRIPTION
# Description

Fix sizing of images dropped on canvas. Images should appear as big as possible, without overflowing the screen or scaling beyond factor of 1.

Import before PR:

https://github.com/user-attachments/assets/cf5fce6d-314a-44af-a644-2d776d82f3d5

Import after PR:

https://github.com/user-attachments/assets/cf0a9acb-ac5f-493e-b78d-683d08916c97

Also fix zoom behavior to allow scaling to 100% of original size, instead of only 80%.

Before:

![CleanShot 2024-09-23 at 01 03 08@2x](https://github.com/user-attachments/assets/bf943212-bce1-4ffa-acc0-6de9284382d0)

After:

![CleanShot 2024-09-23 at 01 03 37@2x](https://github.com/user-attachments/assets/4d8e3b5f-4aa2-44ab-b4ba-79b833b144e7)

## Type of change

Please delete options that are not relevant.

-   [x] Bug fix (non-breaking change which fixes an issue)

## How has this change been tested, please provide a testcase or example of how you tested the change?

- Imported multiple images with different aspect ratios to validate they always show as big as possible, without distorting the screen