### PR TITLE
Bugfix: reset state correctly when dropping a new image

### DIFF
--- a/script.js
+++ b/script.js
@@ -30,7 +30,6 @@ var scaleFactor = 1;
 var scaleSpeed = 0.01;
 
 var points = [];
-var regions = [];
 var masterPoints = [];
 var masterColors = [];
 
@@ -38,9 +37,6 @@ var drawMode;
 setDrawMode('polygon');
 var constrainAngles = false;
 var showNormalized = false;
-
-var modeMessage = document.querySelector('#mode');
-// var coords = document.querySelector('#coords');
 
 function blitCachedCanvas() {
     mainCtx.clearRect(0, 0, canvas.width, canvas.height);
@@ -320,8 +316,6 @@ canvas.addEventListener('drop', function(e) {
         offScreenCtx.drawImage(img, 0, 0);
         blitCachedCanvas();
     };
-    // show coords
-    // document.getElementById('coords').style.display = 'inline-block';
 });
 
 function writePoints(parentPoints) {

--- a/script.js
+++ b/script.js
@@ -23,7 +23,7 @@ offScreenCanvas.width = canvas.width;
 offScreenCanvas.height = canvas.height;
 
 var img = new Image();
-var rgb_color = "#FF00FF"; 
+var rgb_color = color_choices[0];
 var fill_color =  'rgba(0,0,0,0.35)';
 
 var scaleFactor = 1;
@@ -37,6 +37,15 @@ var drawMode;
 setDrawMode('polygon');
 var constrainAngles = false;
 var showNormalized = false;
+
+function resetState() {
+    points = [];
+    masterPoints = [];
+    masterColors = [];
+    rgb_color = color_choices[0];
+    document.querySelector('#json').innerHTML = '';
+    document.querySelector('#python').innerHTML = '';
+}
 
 function blitCachedCanvas() {
     mainCtx.clearRect(0, 0, canvas.width, canvas.height);
@@ -305,6 +314,10 @@ canvas.addEventListener('drop', function(e) {
     }
 
     img.onload = function() {
+        // reset state to initial values
+        resetState();
+
+        // draw loaded image on canvas
         scaleFactor = 0.25;
         canvas.style.width = img.width * scaleFactor + 'px';
         canvas.style.height = img.height * scaleFactor + 'px';
@@ -502,16 +515,12 @@ document.querySelector('#discard-current').addEventListener('click', function(e)
 
 function clearAll() {
     highlightButtonInteraction('#clear')
+    resetState();
+    // reset main and offscreen canvases
     mainCtx.clearRect(0, 0, canvas.width, canvas.height);
     offScreenCtx.clearRect(0, 0, offScreenCanvas.width, offScreenCanvas.height);
     mainCtx.drawImage(img, 0, 0);
     offScreenCtx.drawImage(img, 0, 0);
-    points = [];
-    masterPoints = [];
-    masterColors = [];
-    rgb_color = color_choices[0];
-    document.querySelector('#json').innerHTML = '';
-    document.querySelector('#python').innerHTML = '';
 }
 
 document.querySelector('#clear').addEventListener('click', function(e) {


### PR DESCRIPTION
# Description

When dropping a new image after drawing polygons on another one, the old annotations still show on the new image. This PR fixes that, now whenever a new image is dragged onto the canvas, the state is reset properly.

Before fix:

https://github.com/user-attachments/assets/bcef7814-9cb1-4da7-9fba-88d8f1beddbe

After fix:

https://github.com/user-attachments/assets/0a847c34-6268-4ef8-8a31-eaf2faae13b2

Also clear some old unused variables and comments.

## Type of change

Please delete options that are not relevant.

-   [x] Bug fix (non-breaking change which fixes an issue)

## How has this change been tested, please provide a testcase or example of how you tested the change?

- Dragging an image to canvas
- Annotating on this image
- Dragging another image no top of that
- Drawing new polygons on the new image and checking no old data is present