### PR TITLE
Fix bug that keeps JSON points on screen even after pressing ESC

### DIFF
--- a/script.js
+++ b/script.js
@@ -349,7 +349,7 @@ function writePoints(parentPoints) {
 
     if (!parentPoints.length) {
         document.querySelector('#python').innerHTML = '';
-        document.querySelector('#json').innerHTML;
+        document.querySelector('#json').innerHTML = '';
         return;
     }
 


### PR DESCRIPTION
# Description

Fix bug that keeps JSON points on screen even after pressing ESC

Before:

https://github.com/user-attachments/assets/a41f565d-50eb-44af-a376-21b9e6ca602d

After:

https://github.com/user-attachments/assets/42902da1-c66d-47d8-ab73-51e429d3e6dc

## Type of change

Please delete options that are not relevant.

-   [x] Bug fix (non-breaking change which fixes an issue)

## How has this change been tested, please provide a testcase or example of how you tested the change?

- Annotating an image
- Pressing ESC before the polygon is closed
- Checking that the JSON points are not showing anymore