### PR TITLE
Add fullscreen mode

### DIFF
--- a/index.html
+++ b/index.html
@@ -99,7 +99,6 @@
                                         <span>(Esc)</span>
                                     </span>
                                 </div>
-                                <div class="t-divider"></div>
                                 <div class="t-icon" id="clear">
                                     <i class="fa-solid fa-trash-can"></i>
                                     <span class="ti-caption">
@@ -107,11 +106,19 @@
                                         <span>(Ctrl/⌘-E)</span>
                                     </span>
                                 </div>
+                                <div class="t-divider"></div>
                                 <div class="t-icon" id="save-image">
                                     <i class="fa-solid fa-floppy-disk"></i>
                                     <span class="ti-caption">
                                         <span>Save image</span>
                                         <span>(Ctrl/⌘-S)</span>
+                                    </span>
+                                </div>
+                                <div class="t-icon" id="fullscreen">
+                                    <i class="fa-solid fa-expand"></i>
+                                    <span class="ti-caption">
+                                        <span>Fullscreen</span>
+                                        <span>(F)</span>
                                     </span>
                                 </div>
                             </div>

--- a/script.js
+++ b/script.js
@@ -42,6 +42,9 @@ var showNormalized = false;
 var modeMessage = document.querySelector('#mode');
 // var coords = document.querySelector('#coords');
 
+var isFullscreen = false;
+var taskbarAndCanvas = document.querySelector('.right');
+
 function blitCachedCanvas() {
     mainCtx.clearRect(0, 0, canvas.width, canvas.height);
     mainCtx.drawImage(offScreenCanvas, 0, 0);
@@ -537,6 +540,36 @@ document.querySelector('#save-image').addEventListener('click', function(e) {
     saveImage();
 })
 
+function toggleFullscreen() {
+    highlightButtonInteraction('#fullscreen');
+    
+    if (!isFullscreen) {
+        if (taskbarAndCanvas.requestFullscreen) {
+            taskbarAndCanvas.requestFullscreen();
+        } else if (taskbarAndCanvas.webkitRequestFullscreen) { // Safari
+            taskbarAndCanvas.webkitRequestFullscreen();
+        } else if (taskbarAndCanvas.msRequestFullscreen) { // IE/Edge
+            taskbarAndCanvas.msRequestFullscreen();
+        }
+    } else {
+        if (document.exitFullscreen) {
+            document.exitFullscreen();
+        } else if (document.webkitExitFullscreen) { // Safari
+            document.webkitExitFullscreen();
+        } else if (document.msExitFullscreen) { // IE/Edge
+            document.msExitFullscreen();
+        }
+    }
+}
+
+document.addEventListener('fullscreenchange', function() {
+    isFullscreen = document.fullscreenElement !== null;
+});
+
+document.querySelector('#fullscreen').addEventListener('click', function(e) {
+    toggleFullscreen();
+});
+
 window.addEventListener('keydown', function(e) {
     if (e.key === 'z' && (e.ctrlKey || e.metaKey)) {
         e.preventDefault();
@@ -567,5 +600,9 @@ window.addEventListener('keydown', function(e) {
         if(points.length > 2) {
             onPathClose();
         }
+    }
+
+    if (e.key === 'f' || e.key === 'F') {
+        toggleFullscreen();
     }
 })

--- a/styles.css
+++ b/styles.css
@@ -63,13 +63,13 @@ a {
     display: flex;
 }
 .left {
-    flex: 50%;
+    flex: 40%;
     padding: 0 1em;
     border-right: 1px solid #e5e7eb;
     box-sizing: border-box;
 }
 .right {
-    flex: 50%;
+    flex: 60%;
     padding: 0 2em;
     box-sizing: border-box;
 }
@@ -191,10 +191,6 @@ li {
     flex-direction: column;
     margin-bottom: 1em;
     margin-top: 1em;
-}
-
-.taskbar-container .tc-container {
-    max-width: 700px;
 }
 
 .taskbar {


### PR DESCRIPTION
# Description

Add toggle to change between normal view and fullscreen model. On fullscreen, focus on the taskbar and the image canvas.

https://github.com/user-attachments/assets/abc9258d-2acd-4dbc-b7c4-f7309fb5447a

## Type of change

Please delete options that are not relevant.

-   [x] New feature (non-breaking change which adds functionality)

## How has this change been tested, please provide a testcase or example of how you tested the change?

- Dragged image to canvas
- Toggle fullscreen mode
- Create polygons
- Leave fullscreen and check that positions are correct